### PR TITLE
added an alternative numbers layout that can be shown anywhere

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/keyboard/services/SimpleKeyboardIME.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/keyboard/services/SimpleKeyboardIME.kt
@@ -50,6 +50,7 @@ class SimpleKeyboardIME : InputMethodService(), OnKeyboardActionListener, Shared
     private val KEYBOARD_SYMBOLS_SHIFT = 2
     private val KEYBOARD_NUMBERS = 3
     private val KEYBOARD_PHONE = 4
+    private val KEYBOARD_NUMBERS_ALT = 5
 
     private var keyboard: MyKeyboard? = null
     private var keyboardView: MyKeyboardView? = null
@@ -183,6 +184,10 @@ class SimpleKeyboardIME : InputMethodService(), OnKeyboardActionListener, Shared
                     val keyboardXml = if (keyboardMode == KEYBOARD_SYMBOLS) {
                         keyboardMode = KEYBOARD_SYMBOLS_SHIFT
                         R.xml.keys_symbols_shift
+
+                    } else if (keyboardMode == KEYBOARD_SYMBOLS_SHIFT) {
+                        keyboardMode = KEYBOARD_NUMBERS_ALT
+                        R.xml.keys_numbers_alt
                     } else {
                         keyboardMode = KEYBOARD_SYMBOLS
                         R.xml.keys_symbols
@@ -238,7 +243,9 @@ class SimpleKeyboardIME : InputMethodService(), OnKeyboardActionListener, Shared
                     inputConnection.commitText(codeChar.toString(), 1)
                     val newText = inputConnection.getExtractedText(ExtractedTextRequest(), 0)?.text
                     if (originalText != newText) {
-                        switchToLetters = true
+                        if (keyboardMode != KEYBOARD_NUMBERS_ALT) {
+                            switchToLetters = true
+                        }
                     }
                 } else {
                     when {

--- a/app/src/main/res/xml/keys_letters_bengali.xml
+++ b/app/src/main/res/xml/keys_letters_bengali.xml
@@ -187,7 +187,7 @@
         <Key
             app:code="-2"
             app:keyEdgeFlags="left"
-            app:keyLabel="123"
+            app:keyLabel="\?123"
             app:keyWidth="15%p" />
         <Key
             app:keyLabel=","

--- a/app/src/main/res/xml/keys_letters_bulgarian.xml
+++ b/app/src/main/res/xml/keys_letters_bulgarian.xml
@@ -148,7 +148,7 @@
         <Key
             app:code="-2"
             app:keyEdgeFlags="left"
-            app:keyLabel="123"
+            app:keyLabel="\?123"
             app:keyWidth="15%p" />
         <Key
             app:keyLabel=","

--- a/app/src/main/res/xml/keys_letters_danish.xml
+++ b/app/src/main/res/xml/keys_letters_danish.xml
@@ -184,7 +184,7 @@
         <Key
             app:code="-2"
             app:keyEdgeFlags="left"
-            app:keyLabel="123"
+            app:keyLabel="\?123"
             app:keyWidth="15%p" />
         <Key
             app:keyLabel=","

--- a/app/src/main/res/xml/keys_letters_english_dvorak.xml
+++ b/app/src/main/res/xml/keys_letters_english_dvorak.xml
@@ -151,7 +151,7 @@
         <Key
             app:code="-2"
             app:keyEdgeFlags="left"
-            app:keyLabel="123"
+            app:keyLabel="\?123"
             app:keyWidth="15%p" />
         <Key
             app:keyLabel="q"

--- a/app/src/main/res/xml/keys_letters_english_qwerty.xml
+++ b/app/src/main/res/xml/keys_letters_english_qwerty.xml
@@ -150,7 +150,7 @@
         <Key
             app:code="-2"
             app:keyEdgeFlags="left"
-            app:keyLabel="123"
+            app:keyLabel="\?123"
             app:keyWidth="15%p" />
         <Key
             app:keyLabel=","

--- a/app/src/main/res/xml/keys_letters_english_qwertz.xml
+++ b/app/src/main/res/xml/keys_letters_english_qwertz.xml
@@ -150,7 +150,7 @@
         <Key
             app:code="-2"
             app:keyEdgeFlags="left"
-            app:keyLabel="123"
+            app:keyLabel="\?123"
             app:keyWidth="15%p" />
         <Key
             app:keyLabel=","

--- a/app/src/main/res/xml/keys_letters_french_azerty.xml
+++ b/app/src/main/res/xml/keys_letters_french_azerty.xml
@@ -131,7 +131,7 @@
         <Key
             app:code="-2"
             app:keyEdgeFlags="left"
-            app:keyLabel="123"
+            app:keyLabel="\?123"
             app:keyWidth="15%p" />
         <Key
             app:keyLabel=","

--- a/app/src/main/res/xml/keys_letters_french_bepo.xml
+++ b/app/src/main/res/xml/keys_letters_french_bepo.xml
@@ -150,7 +150,7 @@
         <Key
             app:code="-2"
             app:keyEdgeFlags="left"
-            app:keyLabel="123"
+            app:keyLabel="\?123"
             app:keyWidth="15%p" />
         <Key
             app:keyLabel=","

--- a/app/src/main/res/xml/keys_letters_german.xml
+++ b/app/src/main/res/xml/keys_letters_german.xml
@@ -181,7 +181,7 @@
         <Key
             app:code="-2"
             app:keyEdgeFlags="left"
-            app:keyLabel="123"
+            app:keyLabel="\?123"
             app:keyWidth="15%p" />
         <Key
             app:keyLabel=","

--- a/app/src/main/res/xml/keys_letters_greek.xml
+++ b/app/src/main/res/xml/keys_letters_greek.xml
@@ -162,7 +162,7 @@
         <Key
             app:code="-2"
             app:keyEdgeFlags="left"
-            app:keyLabel="123"
+            app:keyLabel="\?123"
             app:keyWidth="15%p" />
         <Key
             app:keyLabel=","

--- a/app/src/main/res/xml/keys_letters_lithuanian.xml
+++ b/app/src/main/res/xml/keys_letters_lithuanian.xml
@@ -150,7 +150,7 @@
         <Key
             app:code="-2"
             app:keyEdgeFlags="left"
-            app:keyLabel="123"
+            app:keyLabel="\?123"
             app:keyWidth="15%p" />
         <Key
             app:keyLabel=","

--- a/app/src/main/res/xml/keys_letters_norwegian.xml
+++ b/app/src/main/res/xml/keys_letters_norwegian.xml
@@ -184,7 +184,7 @@
         <Key
             app:code="-2"
             app:keyEdgeFlags="left"
-            app:keyLabel="123"
+            app:keyLabel="\?123"
             app:keyWidth="15%p" />
         <Key
             app:keyLabel=","

--- a/app/src/main/res/xml/keys_letters_polish.xml
+++ b/app/src/main/res/xml/keys_letters_polish.xml
@@ -144,7 +144,7 @@
         <Key
             app:code="-2"
             app:keyEdgeFlags="left"
-            app:keyLabel="123"
+            app:keyLabel="\?123"
             app:keyWidth="15%p" />
         <Key
             app:keyLabel=","

--- a/app/src/main/res/xml/keys_letters_romanian.xml
+++ b/app/src/main/res/xml/keys_letters_romanian.xml
@@ -135,7 +135,7 @@
         <Key
             app:code="-2"
             app:keyEdgeFlags="left"
-            app:keyLabel="123"
+            app:keyLabel="\?123"
             app:keyWidth="15%p" />
         <Key
             app:keyLabel=","

--- a/app/src/main/res/xml/keys_letters_russian.xml
+++ b/app/src/main/res/xml/keys_letters_russian.xml
@@ -184,7 +184,7 @@
         <Key
             app:code="-2"
             app:keyEdgeFlags="left"
-            app:keyLabel="123"
+            app:keyLabel="\?123"
             app:keyWidth="15%p" />
         <Key
             app:keyLabel=","

--- a/app/src/main/res/xml/keys_letters_slovenian.xml
+++ b/app/src/main/res/xml/keys_letters_slovenian.xml
@@ -137,7 +137,7 @@
         <Key
             app:code="-2"
             app:keyEdgeFlags="left"
-            app:keyLabel="123"
+            app:keyLabel="\?123"
             app:keyWidth="15%p" />
         <Key
             app:keyLabel=","

--- a/app/src/main/res/xml/keys_letters_spanish_qwerty.xml
+++ b/app/src/main/res/xml/keys_letters_spanish_qwerty.xml
@@ -148,7 +148,7 @@
         <Key
             app:code="-2"
             app:keyEdgeFlags="left"
-            app:keyLabel="123"
+            app:keyLabel="\?123"
             app:keyWidth="15%p" />
         <Key
             app:keyLabel=","

--- a/app/src/main/res/xml/keys_letters_swedish.xml
+++ b/app/src/main/res/xml/keys_letters_swedish.xml
@@ -183,7 +183,7 @@
         <Key
             app:code="-2"
             app:keyEdgeFlags="left"
-            app:keyLabel="123"
+            app:keyLabel="\?123"
             app:keyWidth="15%p" />
         <Key
             app:keyLabel=","

--- a/app/src/main/res/xml/keys_letters_turkish_q.xml
+++ b/app/src/main/res/xml/keys_letters_turkish_q.xml
@@ -158,7 +158,7 @@
         <Key
             app:code="-2"
             app:keyEdgeFlags="left"
-            app:keyLabel="123"
+            app:keyLabel="\?123"
             app:keyWidth="15%p" />
         <Key
             app:keyLabel=","

--- a/app/src/main/res/xml/keys_letters_ukrainian.xml
+++ b/app/src/main/res/xml/keys_letters_ukrainian.xml
@@ -157,7 +157,7 @@
         <Key
             app:code="-2"
             app:keyEdgeFlags="left"
-            app:keyLabel="123"
+            app:keyLabel="\?123"
             app:keyWidth="15%p" />
         <Key
             app:keyLabel=","

--- a/app/src/main/res/xml/keys_numbers_alt.xml
+++ b/app/src/main/res/xml/keys_numbers_alt.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto">
+    <Row>
+        <Key
+            app:keyEdgeFlags="left"
+            app:keyLabel="("
+            app:keyWidth="12.5%p" />
+        <Key
+            app:keyLabel=")"
+            app:keyWidth="12.5%p" />
+        <Key
+            app:keyLabel="1"
+            app:keyWidth="20%p" />
+        <Key
+            app:keyLabel="2"
+            app:keyWidth="20%p" />
+        <Key
+            app:keyLabel="3"
+            app:keyWidth="20%p" />
+        <Key
+            app:code="32"
+            app:keyEdgeFlags="right"
+            app:keyLabel="␣"
+            app:keyWidth="15%p" />
+    </Row>
+    <Row>
+        <Key
+            app:keyEdgeFlags="left"
+            app:keyLabel="+"
+            app:keyWidth="12.5%p" />
+        <Key
+            app:keyLabel="-"
+            app:keyWidth="12.5%p" />
+        <Key
+            app:keyLabel="4"
+            app:keyWidth="20%p" />
+        <Key
+            app:keyLabel="5"
+            app:keyWidth="20%p" />
+        <Key
+            app:keyLabel="6"
+            app:keyWidth="20%p" />
+        <Key
+            app:keyEdgeFlags="right"
+            app:keyLabel=""
+            app:keyWidth="15%p" />
+    </Row>
+    <Row>
+        <Key
+            app:keyLabel="/"
+            app:keyWidth="12.5%p" />
+        <Key
+            app:keyLabel="%"
+            app:keyWidth="12.5%p" />
+        <Key
+            app:keyEdgeFlags="left"
+            app:keyLabel="7"
+            app:keyWidth="20%p" />
+        <Key
+            app:keyLabel="8"
+            app:keyWidth="20%p" />
+        <Key
+            app:keyLabel="9"
+            app:keyWidth="20%p" />
+        <Key
+            app:code="-5"
+            app:isRepeatable="true"
+            app:keyEdgeFlags="right"
+            app:keyIcon="@drawable/ic_clear_vector"
+            app:keyWidth="15%p" />
+    </Row>
+    <Row>
+        <Key
+            app:code="-1"
+            app:keyEdgeFlags="left"
+            app:keyLabel="\?123"
+            app:keyWidth="12.5%p" /> />
+        <Key
+            app:keyLabel=","
+            app:keyWidth="12.5%p" />
+        <Key
+            app:keyLabel="*"
+            app:keyWidth="20%p" />
+        <Key
+            app:keyLabel="0"
+            app:keyWidth="20%p" />
+        <Key
+            app:keyLabel="."
+            app:keyWidth="20%p" />
+        <Key
+            app:code="-4"
+            app:keyEdgeFlags="right"
+            app:keyIcon="@drawable/ic_enter_vector"
+            app:keyWidth="15%p" />
+    </Row>
+</Keyboard>

--- a/app/src/main/res/xml/keys_symbols_shift.xml
+++ b/app/src/main/res/xml/keys_symbols_shift.xml
@@ -36,7 +36,7 @@
         <Key
             app:code="-1"
             app:keyEdgeFlags="left"
-            app:keyLabel="\?123"
+            app:keyLabel="123"
             app:keyWidth="15%p" />
         <Key app:keyLabel="¡" />
         <Key


### PR DESCRIPTION
Adds an alternative numbers layout which one can use anywhere not only for number fields. 

Useful for typing phone numbers and other numbers in the notes app for example.