### PR TITLE
Update Romanian layout

### DIFF
--- a/app/src/main/res/xml/keys_letters_romanian.xml
+++ b/app/src/main/res/xml/keys_letters_romanian.xml
@@ -34,7 +34,7 @@
             app:keyLabel="0"
             app:topSmallNumber="0" />
     </Row>
-    <Row>
+    <Row app:keyWidth="9.09%p">
         <Key
             app:keyEdgeFlags="left"
             app:keyLabel="q"
@@ -82,15 +82,16 @@
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="9" />
         <Key
-            app:keyEdgeFlags="right"
             app:keyLabel="p"
             app:popupCharacters="0"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="0" />
-    </Row>
-    <Row>
         <Key
-            app:horizontalGap="5%"
+            app:keyEdgeFlags="right"
+            app:keyLabel="ă" />
+    </Row>
+    <Row app:keyWidth="9.09%p">
+        <Key
             app:keyEdgeFlags="left"
             app:keyLabel="a"
             app:popupCharacters="ăâ"
@@ -106,17 +107,19 @@
         <Key app:keyLabel="j" />
         <Key app:keyLabel="k" />
         <Key
-            app:keyEdgeFlags="right"
             app:keyLabel="l"
             app:popupCharacters="ĺľ"
             app:popupKeyboard="@xml/keyboard_popup_template" />
+        <Key app:keyLabel="ș" />
+        <Key
+            app:keyEdgeFlags="right"
+            app:keyLabel="ț" />
     </Row>
-    <Row>
+    <Row app:keyWidth="9.09%p">
         <Key
             app:code="-1"
             app:keyEdgeFlags="left"
-            app:keyIcon="@drawable/ic_caps_outline_vector"
-            app:keyWidth="15%p" />
+            app:keyIcon="@drawable/ic_caps_outline_vector" />
         <Key app:keyLabel="z" />
         <Key app:keyLabel="x" />
         <Key app:keyLabel="c" />
@@ -124,12 +127,13 @@
         <Key app:keyLabel="b" />
         <Key app:keyLabel="n" />
         <Key app:keyLabel="m" />
+        <Key app:keyLabel="î" />
+        <Key app:keyLabel="â" />
         <Key
             app:code="-5"
             app:isRepeatable="true"
             app:keyEdgeFlags="right"
-            app:keyIcon="@drawable/ic_clear_vector"
-            app:keyWidth="15%p" />
+            app:keyIcon="@drawable/ic_clear_vector" />
     </Row>
     <Row>
         <Key


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [ ] Bugfix
- [X] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
Updated the Romanian layout to include the letters Ă Â Î Ș Ț as separate keys.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before: No keys for Ă Â Î Ș Ț
- After:
![image](https://github.com/FossifyOrg/Keyboard/assets/139619642/7b7a6c58-a68e-4fd7-8207-ab4ce96fa836)

#### Acknowledgement
- [X] I read the [contribution guidelines](https://github.com/FossifyOrg/Keyboard/blob/main/CONTRIBUTING.md).
