### PR TITLE
fix: do case-sensitive search when creating clips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Clipboard saving is now case-sensitive ([#202])
 
 ## [1.2.2] - 2025-07-18
 ### Changed
@@ -50,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0] - 2024-07-18
 ### Added
 - Initial release
+
+[#202]: https://github.com/FossifyOrg/Keyboard/issues/202
 
 [Unreleased]: https://github.com/FossifyOrg/Keyboard/compare/1.2.2...HEAD
 [1.2.2]: https://github.com/FossifyOrg/Keyboard/compare/1.2.1...1.2.2

--- a/app/src/main/kotlin/org/fossify/keyboard/interfaces/ClipsDao.kt
+++ b/app/src/main/kotlin/org/fossify/keyboard/interfaces/ClipsDao.kt
@@ -11,7 +11,7 @@ interface ClipsDao {
     @Query("SELECT * FROM clips ORDER BY id")
     fun getClips(): List<Clip>
 
-    @Query("SELECT id FROM clips WHERE value = :value COLLATE NOCASE")
+    @Query("SELECT id FROM clips WHERE value = :value")
     fun getClipWithValue(value: String): Long?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Switched to case-sensitive search when looking for existing duplicate clips.

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes #202

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [ ] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
