### PR TITLE
fix: perform haptic feedback on cursor move

### DIFF
--- a/app/src/main/kotlin/org/fossify/keyboard/services/SimpleKeyboardIME.kt
+++ b/app/src/main/kotlin/org/fossify/keyboard/services/SimpleKeyboardIME.kt
@@ -417,15 +417,20 @@ class SimpleKeyboardIME : InputMethodService(), OnKeyboardActionListener, Shared
     }
 
     private fun moveCursor(moveRight: Boolean) {
-        val extractedText = currentInputConnection?.getExtractedText(ExtractedTextRequest(), 0) ?: return
-        var newCursorPosition = extractedText.selectionStart
-        newCursorPosition = if (moveRight) {
-            newCursorPosition + 1
+        val inputConnection = currentInputConnection
+        val extractedText = inputConnection.getExtractedText(ExtractedTextRequest(), 0) ?: return
+        val text = extractedText.text ?: return
+        val oldPos = extractedText.selectionStart
+        val newPos = if (moveRight) {
+            oldPos + 1
         } else {
-            newCursorPosition - 1
-        }
+            oldPos - 1
+        }.coerceIn(0, text.length)
 
-        currentInputConnection?.setSelection(newCursorPosition, newCursorPosition)
+        if (newPos != oldPos) {
+            inputConnection?.setSelection(newPos, newPos)
+            keyboardView?.performHapticHandleMove()
+        }
     }
 
     private fun getImeOptionsActionId(): Int {

--- a/app/src/main/kotlin/org/fossify/keyboard/views/MyKeyboardView.kt
+++ b/app/src/main/kotlin/org/fossify/keyboard/views/MyKeyboardView.kt
@@ -14,6 +14,7 @@ import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.os.Message
+import android.os.SystemClock
 import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.*
@@ -33,6 +34,7 @@ import androidx.emoji2.text.EmojiCompat.EMOJI_SUPPORTED
 import androidx.recyclerview.widget.GridLayoutManager.SpanSizeLookup
 import org.fossify.commons.extensions.*
 import org.fossify.commons.helpers.ensureBackgroundThread
+import org.fossify.commons.helpers.isOreoMr1Plus
 import org.fossify.commons.helpers.isPiePlus
 import org.fossify.keyboard.R
 import org.fossify.keyboard.activities.ManageClipboardItemsActivity
@@ -143,6 +145,7 @@ class MyKeyboardView @JvmOverloads constructor(
     private var mTopSmallNumberMarginHeight = 0f
     private val mSpaceMoveThreshold: Int
     private var ignoreTouches = false
+    private var lastHandleMoveAt = 0L
 
     private var mKeyBackground: Drawable? = null
     private var mShowKeyBorders: Boolean = false
@@ -185,6 +188,7 @@ class MyKeyboardView @JvmOverloads constructor(
         private const val REPEAT_INTERVAL = 50 // ~20 keys per second
         private const val REPEAT_START_DELAY = 400
         private val LONGPRESS_TIMEOUT = ViewConfiguration.getLongPressTimeout()
+        private const val HANDLE_MOVE_MIN_MS = 30L
     }
 
     init {
@@ -488,6 +492,20 @@ class MyKeyboardView @JvmOverloads constructor(
     fun vibrateIfNeeded() {
         if (context.config.vibrateOnKeypress) {
             performHapticFeedback()
+        }
+    }
+
+    fun performHapticHandleMove() {
+        if (!context.config.vibrateOnKeypress) return
+        val now = SystemClock.uptimeMillis()
+        if (now - lastHandleMoveAt < HANDLE_MOVE_MIN_MS) return
+        lastHandleMoveAt = now
+        if (isOreoMr1Plus()) {
+            @Suppress("DEPRECATION")
+            performHapticFeedback(
+                HapticFeedbackConstants.TEXT_HANDLE_MOVE,
+                HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING
+            )
         }
     }
 

--- a/app/src/main/kotlin/org/fossify/keyboard/views/MyKeyboardView.kt
+++ b/app/src/main/kotlin/org/fossify/keyboard/views/MyKeyboardView.kt
@@ -188,7 +188,7 @@ class MyKeyboardView @JvmOverloads constructor(
         private const val REPEAT_INTERVAL = 50 // ~20 keys per second
         private const val REPEAT_START_DELAY = 400
         private val LONGPRESS_TIMEOUT = ViewConfiguration.getLongPressTimeout()
-        private const val HANDLE_MOVE_MIN_MS = 30L
+        private const val HANDLE_MOVE_MIN_MS = 35L
     }
 
     init {


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Updated `moveCursor()` to perform a [`TEXT_HANDLE_MOVE`](https://developer.android.com/reference/android/view/HapticFeedbackConstants#TEXT_HANDLE_MOVE) type haptic feedback. This is not compatible with all devices.

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Keyboard/issues/222

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
