### PR TITLE
fix: make accented vowels default in Spanish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- Improved French AZERTY layout ([#134])
+- Updated French AZERTY layout ([#134])
+- Updated Spanish layout ([#206])
 
 ### Added
 - German QWERTZ layout without dedicated umlaut keys ([#47])

--- a/app/src/main/res/xml/keys_letters_spanish_qwerty.xml
+++ b/app/src/main/res/xml/keys_letters_spanish_qwerty.xml
@@ -48,7 +48,7 @@
             app:topSmallNumber="2" />
         <Key
             app:keyLabel="e"
-            app:popupCharacters="êè3éëēęė"
+            app:popupCharacters="êèé3ëēęė"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="3" />
         <Key
@@ -68,17 +68,17 @@
             app:topSmallNumber="6" />
         <Key
             app:keyLabel="u"
-            app:popupCharacters="ūûü7úùű"
+            app:popupCharacters="ūûüú7ùű"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="7" />
         <Key
             app:keyLabel="i"
-            app:popupCharacters="ïīì8íî"
+            app:popupCharacters="ïīìí8î"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="8" />
         <Key
             app:keyLabel="o"
-            app:popupCharacters="őõōöøôò9ó"
+            app:popupCharacters="őõōöøôòó9"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="9" />
         <Key


### PR DESCRIPTION
Closes https://github.com/FossifyOrg/Keyboard/issues/206