### PR TITLE
fix: reorder umlauts in German layouts

### DIFF
--- a/app/src/main/res/xml/keys_letters_german.xml
+++ b/app/src/main/res/xml/keys_letters_german.xml
@@ -75,7 +75,7 @@
         <Key
             app:keyLabel="u"
             app:keyWidth="9.05%p"
-            app:popupCharacters="űúùü7ûū"
+            app:popupCharacters="űú7üùûū"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="7" />
         <Key
@@ -87,7 +87,7 @@
         <Key
             app:keyLabel="o"
             app:keyWidth="9.05%p"
-            app:popupCharacters="őóôòõōö9"
+            app:popupCharacters="őóôòõ9öō"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="9" />
         <Key

--- a/app/src/main/res/xml/keys_letters_german_qwertz.xml
+++ b/app/src/main/res/xml/keys_letters_german_qwertz.xml
@@ -68,7 +68,7 @@
             app:topSmallNumber="6" />
         <Key
             app:keyLabel="u"
-            app:popupCharacters="űúùü7ûū"
+            app:popupCharacters="űú7üùûū"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="7" />
         <Key
@@ -78,7 +78,7 @@
             app:topSmallNumber="8" />
         <Key
             app:keyLabel="o"
-            app:popupCharacters="őóôòõōö9"
+            app:popupCharacters="őóôòõ9öō"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="9" />
         <Key


### PR DESCRIPTION
See https://github.com/FossifyOrg/Keyboard/issues/47#issuecomment-3226019276