### PR TITLE
fix: use activity context in keyboard language management dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- German QWERTZ layout without dedicated umlaut keys ([#47])
+
 ### Changed
 - Updated French AZERTY layout ([#134])
 - Updated Spanish layout ([#206])
 
-### Added
-- German QWERTZ layout without dedicated umlaut keys ([#47])
+### Fixed
+- Keyboard language management dialog now respects `Use English language` preference ([#238])
 
 ## [1.4.0] - 2025-08-22
 ### Added
@@ -83,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#202]: https://github.com/FossifyOrg/Keyboard/issues/202
 [#222]: https://github.com/FossifyOrg/Keyboard/issues/222
 [#230]: https://github.com/FossifyOrg/Keyboard/issues/230
+[#238]: https://github.com/FossifyOrg/Keyboard/issues/238
 
 [Unreleased]: https://github.com/FossifyOrg/Keyboard/compare/1.4.0...HEAD
 [1.4.0]: https://github.com/FossifyOrg/Keyboard/compare/1.3.0...1.4.0

--- a/app/src/main/kotlin/org/fossify/keyboard/adapters/ManageKeyboardLanguagesAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/keyboard/adapters/ManageKeyboardLanguagesAdapter.kt
@@ -28,7 +28,7 @@ internal class ManageKeyboardLanguagesAdapter(
     override fun onBindViewHolder(holder: MyViewHolder, position: Int) {
         val item = languagesList[position]
         holder.languageCheckboxItem.apply {
-            text = config.context.getKeyboardLanguageText(item)
+            text = context.getKeyboardLanguageText(item)
             isChecked = selectedLanguages.contains(item)
 
             setOnClickListener {
@@ -47,7 +47,7 @@ internal class ManageKeyboardLanguagesAdapter(
 
     fun getSelectedLanguages(): MutableSet<Int> {
         val defaultLang = config.getDefaultLanguage()
-        if (selectedLanguages.size == 0) {
+        if (selectedLanguages.isEmpty()) {
             selectedLanguages.add(defaultLang)
         }
         return selectedLanguages


### PR DESCRIPTION

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
Replaced application context usage with activity context in `ManageKeyboardLanguagesAdapter` so that the proper resource is resolved as per the attached base context in BaseSimpleActivity.

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Keyboard/issues/238

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
