### PR TITLE
fix: use proper sorting in keyboard language selection dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Keyboard language management dialog now respects `Use English language` preference ([#238])
+- Fixed incorrect sorting in keyboard language selection dialog ([#239])
 
 ## [1.4.0] - 2025-08-22
 ### Added
@@ -87,6 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#222]: https://github.com/FossifyOrg/Keyboard/issues/222
 [#230]: https://github.com/FossifyOrg/Keyboard/issues/230
 [#238]: https://github.com/FossifyOrg/Keyboard/issues/238
+[#239]: https://github.com/FossifyOrg/Keyboard/issues/239
 
 [Unreleased]: https://github.com/FossifyOrg/Keyboard/compare/1.4.0...HEAD
 [1.4.0]: https://github.com/FossifyOrg/Keyboard/compare/1.3.0...1.4.0

--- a/app/src/main/kotlin/org/fossify/keyboard/adapters/ManageKeyboardLanguagesAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/keyboard/adapters/ManageKeyboardLanguagesAdapter.kt
@@ -6,12 +6,13 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import org.fossify.commons.views.MyAppCompatCheckbox
 import org.fossify.keyboard.R
-import org.fossify.keyboard.extensions.getKeyboardLanguageText
 import org.fossify.keyboard.helpers.Config
+
+typealias LanguageItem = Pair<Int, String>
 
 internal class ManageKeyboardLanguagesAdapter(
     private val config: Config,
-    private var languagesList: List<Int>,
+    private var languagesList: List<LanguageItem>,
 ) : RecyclerView.Adapter<ManageKeyboardLanguagesAdapter.MyViewHolder>() {
     private val selectedLanguages = config.selectedLanguages
 
@@ -28,14 +29,14 @@ internal class ManageKeyboardLanguagesAdapter(
     override fun onBindViewHolder(holder: MyViewHolder, position: Int) {
         val item = languagesList[position]
         holder.languageCheckboxItem.apply {
-            text = context.getKeyboardLanguageText(item)
-            isChecked = selectedLanguages.contains(item)
+            text = item.second
+            isChecked = selectedLanguages.contains(item.first)
 
             setOnClickListener {
                 if (isChecked) {
-                    selectedLanguages.add(item)
+                    selectedLanguages.add(item.first)
                 } else {
-                    selectedLanguages.remove(item)
+                    selectedLanguages.remove(item.first)
                 }
             }
         }

--- a/app/src/main/kotlin/org/fossify/keyboard/dialogs/ManageKeyboardLanguagesDialog.kt
+++ b/app/src/main/kotlin/org/fossify/keyboard/dialogs/ManageKeyboardLanguagesDialog.kt
@@ -7,6 +7,7 @@ import org.fossify.keyboard.R
 import org.fossify.keyboard.adapters.ManageKeyboardLanguagesAdapter
 import org.fossify.keyboard.databinding.DialogManageKeyboardLanguagesBinding
 import org.fossify.keyboard.extensions.config
+import org.fossify.keyboard.extensions.getKeyboardLanguageText
 import org.fossify.keyboard.helpers.SUPPORTED_LANGUAGES
 
 class ManageKeyboardLanguagesDialog(
@@ -15,7 +16,11 @@ class ManageKeyboardLanguagesDialog(
 ) {
     init {
         val binding = DialogManageKeyboardLanguagesBinding.inflate(activity.layoutInflater)
-        val adapter = ManageKeyboardLanguagesAdapter(activity.config, SUPPORTED_LANGUAGES)
+        val languageItems = SUPPORTED_LANGUAGES.map {
+            it to activity.getKeyboardLanguageText(it)
+        }.sortedBy { it.second }
+
+        val adapter = ManageKeyboardLanguagesAdapter(activity.config, languageItems)
         binding.keyboardLanguageList.adapter = adapter
 
         activity.getAlertDialogBuilder()

--- a/app/src/main/kotlin/org/fossify/keyboard/extensions/Context.kt
+++ b/app/src/main/kotlin/org/fossify/keyboard/extensions/Context.kt
@@ -270,6 +270,8 @@ fun Context.getKeyboardLanguagesRadioItems(): ArrayList<RadioItem> {
     }
 
     return selectedLanguagesRadioItems
+        .sortedBy { it.title }
+        .toMutableList() as ArrayList<RadioItem>
 }
 
 fun Context.getKeyboardLanguageText(language: Int): String {


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
Applied alphabetical sorting on language items before displaying them in dialogs.

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Keyboard/issues/239

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
