### PR TITLE
fix: remove non-Italian characters from Italian layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated French AZERTY layout ([#134])
 - Updated Spanish layout ([#206])
+- Updated Italian layout ([#251])
 
 ### Fixed
 - Keyboard language management dialog now respects `Use English language` preference ([#238])
@@ -89,6 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#230]: https://github.com/FossifyOrg/Keyboard/issues/230
 [#238]: https://github.com/FossifyOrg/Keyboard/issues/238
 [#239]: https://github.com/FossifyOrg/Keyboard/issues/239
+[#251]: https://github.com/FossifyOrg/Keyboard/issues/251
 
 [Unreleased]: https://github.com/FossifyOrg/Keyboard/compare/1.4.0...HEAD
 [1.4.0]: https://github.com/FossifyOrg/Keyboard/compare/1.3.0...1.4.0

--- a/app/src/main/res/xml/keys_letters_italian.xml
+++ b/app/src/main/res/xml/keys_letters_italian.xml
@@ -48,7 +48,7 @@
             app:topSmallNumber="2" />
         <Key
             app:keyLabel="e"
-            app:popupCharacters="3éè"
+            app:popupCharacters="3èé"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="3" />
         <Key
@@ -63,22 +63,22 @@
             app:topSmallNumber="5" />
         <Key
             app:keyLabel="y"
-            app:popupCharacters="6¥"
+            app:popupCharacters="6"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="6" />
         <Key
             app:keyLabel="u"
-            app:popupCharacters="7ùú"
+            app:popupCharacters="7ù"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="7" />
         <Key
             app:keyLabel="i"
-            app:popupCharacters="8ìí"
+            app:popupCharacters="8ì"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="8" />
         <Key
             app:keyLabel="o"
-            app:popupCharacters="9òóø"
+            app:popupCharacters="9ò"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="9" />
         <Key
@@ -93,11 +93,11 @@
             app:horizontalGap="5%"
             app:keyEdgeFlags="left"
             app:keyLabel="a"
-            app:popupCharacters="àáæ"
+            app:popupCharacters="à"
             app:popupKeyboard="@xml/keyboard_popup_template" />
         <Key
             app:keyLabel="s"
-            app:popupCharacters="ß"
+            app:popupCharacters=""
             app:popupKeyboard="@xml/keyboard_popup_template" />
         <Key app:keyLabel="d" />
         <Key app:keyLabel="f" />
@@ -117,13 +117,13 @@
         <Key app:keyLabel="x" />
         <Key
             app:keyLabel="c"
-            app:popupCharacters="ç¢"
+            app:popupCharacters=""
             app:popupKeyboard="@xml/keyboard_popup_template" />
         <Key app:keyLabel="v" />
         <Key app:keyLabel="b" />
         <Key
             app:keyLabel="n"
-            app:popupCharacters="ñ"
+            app:popupCharacters=""
             app:popupKeyboard="@xml/keyboard_popup_template" />
         <Key app:keyLabel="m" />
         <Key

--- a/app/src/main/res/xml/keys_letters_italian.xml
+++ b/app/src/main/res/xml/keys_letters_italian.xml
@@ -117,7 +117,7 @@
         <Key app:keyLabel="x" />
         <Key
             app:keyLabel="c"
-            app:popupCharacters=""
+            app:popupCharacters="ç"
             app:popupKeyboard="@xml/keyboard_popup_template" />
         <Key app:keyLabel="v" />
         <Key app:keyLabel="b" />

--- a/app/src/main/res/xml/keys_letters_italian.xml
+++ b/app/src/main/res/xml/keys_letters_italian.xml
@@ -68,17 +68,17 @@
             app:topSmallNumber="6" />
         <Key
             app:keyLabel="u"
-            app:popupCharacters="7ù"
+            app:popupCharacters="ù7"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="7" />
         <Key
             app:keyLabel="i"
-            app:popupCharacters="8ì"
+            app:popupCharacters="ì8"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="8" />
         <Key
             app:keyLabel="o"
-            app:popupCharacters="9ò"
+            app:popupCharacters="ò9"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="9" />
         <Key


### PR DESCRIPTION

<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Removed ¢, ¥, ß, á, æ, ç, í, ñ, ó, ø, ú popup characters
- Made è the default character when long pressing 3

#### Before & after preview
<!-- For changes affecting UI, consider attaching screenshots or a video. Delete this section otherwise. -->

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Keyboard/issues/251

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
