### PR TITLE
fix: Vibrate Keypress On by default

### DIFF
--- a/app/src/main/kotlin/org/fossify/keyboard/helpers/Config.kt
+++ b/app/src/main/kotlin/org/fossify/keyboard/helpers/Config.kt
@@ -12,7 +12,7 @@ class Config(context: Context) : BaseConfig(context) {
     }
 
     var vibrateOnKeypress: Boolean
-        get() = prefs.getBoolean(VIBRATE_ON_KEYPRESS, true)
+        get() = prefs.getBoolean(VIBRATE_ON_KEYPRESS, false)
         set(vibrateOnKeypress) = prefs.edit().putBoolean(VIBRATE_ON_KEYPRESS, vibrateOnKeypress).apply()
 
     var showPopupOnKeypress: Boolean


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Turns vibrate on keypress of by default
- Easier for new users

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes #268

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
