### PR TITLE
fix: change default diacritic for "z" in Polish

### DIFF
--- a/app/src/main/res/xml/keys_letters_polish.xml
+++ b/app/src/main/res/xml/keys_letters_polish.xml
@@ -119,7 +119,7 @@
             app:keyWidth="15%p" />
         <Key
             app:keyLabel="z"
-            app:popupCharacters="źż"
+            app:popupCharacters="żź"
             app:popupKeyboard="@xml/keyboard_popup_template" />
         <Key app:keyLabel="x" />
         <Key


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why

Changed default diacritic for "z" in Polish, as "ż" is more common than "ź".

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Wrote text with "ż" using Fossify Keyboard on an emulator.

#### Checklist
- [X] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [X] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [X] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [ ] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
