### PR TITLE
fix: setup edge-to-edge using compat helper

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,2 +1,1 @@
--keep class org.fossify.keyboard.helpers.MyKeyboard { *; }
 -keep class org.fossify.keyboard.helpers.MyKeyboard$Key { *; }

--- a/app/src/main/kotlin/org/fossify/keyboard/services/SimpleKeyboardIME.kt
+++ b/app/src/main/kotlin/org/fossify/keyboard/services/SimpleKeyboardIME.kt
@@ -86,7 +86,7 @@ class SimpleKeyboardIME : InputMethodService(), OnKeyboardActionListener, Shared
             setKeyboardHolder(binding)
             setKeyboard(keyboard!!)
             setEditorInfo(currentInputEditorInfo)
-            setupNavigationBarPadding()
+            setupEdgeToEdge()
             mOnKeyboardActionListener = this@SimpleKeyboardIME
         }
 
@@ -553,13 +553,13 @@ class SimpleKeyboardIME : InputMethodService(), OnKeyboardActionListener, Shared
         }
     }
 
-    private fun setupNavigationBarPadding() {
+    private fun setupEdgeToEdge() {
         window.window?.apply {
-            WindowCompat.setDecorFitsSystemWindows(this, false)
+            WindowCompat.enableEdgeToEdge(this)
             ViewCompat.setOnApplyWindowInsetsListener(binding.keyboardHolder) { view, insets ->
                 val bottomPadding = insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom
                 binding.keyboardHolder.updatePadding(bottom = bottomPadding)
-                ViewCompat.onApplyWindowInsets(view, insets)
+                insets
             }
         }
     }


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Added a call to `WindowCompat.enableEdgeToEdge()` for proper setup. 
- Removed the unnecessary call to `ViewCompat.onApplyWindowInsets()`.
- Renamed `setupNavigationBarPadding()` to `setupEdgeToEdge()`.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Testing rotation, typing, themes.

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- This one is not tracked.

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
