### PR TITLE
fix: ensure proper insets are applied on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed invisible numbers in the top row ([#100])
+- Fixed overlap between keyboard and navigation bar ([#117])
 
 ## [1.5.0] - 2025-09-23
 ### Added
@@ -102,6 +103,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#47]: https://github.com/FossifyOrg/Keyboard/issues/47
 [#78]: https://github.com/FossifyOrg/Keyboard/issues/78
 [#100]: https://github.com/FossifyOrg/Keyboard/issues/100
+[#117]: https://github.com/FossifyOrg/Keyboard/issues/117
 [#133]: https://github.com/FossifyOrg/Keyboard/issues/133
 [#134]: https://github.com/FossifyOrg/Keyboard/issues/134
 [#136]: https://github.com/FossifyOrg/Keyboard/issues/136

--- a/app/src/main/kotlin/org/fossify/keyboard/services/SimpleKeyboardIME.kt
+++ b/app/src/main/kotlin/org/fossify/keyboard/services/SimpleKeyboardIME.kt
@@ -31,7 +31,7 @@ import androidx.autofill.inline.v1.InlineSuggestionUi
 import androidx.core.graphics.drawable.toBitmap
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
-import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsCompat.Type
 import androidx.core.view.updatePadding
 import org.fossify.commons.extensions.*
 import org.fossify.commons.helpers.*
@@ -96,6 +96,9 @@ class SimpleKeyboardIME : InputMethodService(), OnKeyboardActionListener, Shared
     override fun onStartInputView(editorInfo: EditorInfo?, restarting: Boolean) {
         super.onStartInputView(editorInfo, restarting)
         updateBackgroundColors()
+        binding.keyboardHolder.post {
+            ViewCompat.requestApplyInsets(binding.keyboardHolder)
+        }
     }
 
     override fun onPress(primaryCode: Int) {
@@ -557,8 +560,8 @@ class SimpleKeyboardIME : InputMethodService(), OnKeyboardActionListener, Shared
         window.window?.apply {
             WindowCompat.enableEdgeToEdge(this)
             ViewCompat.setOnApplyWindowInsetsListener(binding.keyboardHolder) { view, insets ->
-                val bottomPadding = insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom
-                binding.keyboardHolder.updatePadding(bottom = bottomPadding)
+                val system = insets.getInsetsIgnoringVisibility(Type.navigationBars())
+                binding.keyboardHolder.updatePadding(bottom = system.bottom)
                 insets
             }
         }


### PR DESCRIPTION

<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Requested insets in `onStartInputView()` to ensure proper insets are always applied.
- Switched to `getInsetsIgnoringVisibility()` just in case.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Played Big Buck Bunny on full-screen on a Pixel 2 emulator running Android 10. No overlap after entering/exiting full-screen view.

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Keyboard/issues/117

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
