### PR TITLE
fix: ensure binding is initialized before accessing properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Option to disable the emoji key ([#234])
 
+### Fixed
+- Fixed crash on initial startup in some cases ([#335])
+
 ## [1.6.0] - 2025-10-29
 ### Added
 - Added Colemak, Colemak-DH, Workman, Asset, Niro, Soul layouts
@@ -125,6 +128,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#259]: https://github.com/FossifyOrg/Keyboard/issues/259
 [#265]: https://github.com/FossifyOrg/Keyboard/issues/265
 [#274]: https://github.com/FossifyOrg/Keyboard/issues/274
+[#335]: https://github.com/FossifyOrg/Keyboard/issues/335
 
 [Unreleased]: https://github.com/FossifyOrg/Keyboard/compare/1.6.0...HEAD
 [1.6.0]: https://github.com/FossifyOrg/Keyboard/compare/1.5.0...1.6.0

--- a/app/src/main/kotlin/org/fossify/keyboard/services/SimpleKeyboardIME.kt
+++ b/app/src/main/kotlin/org/fossify/keyboard/services/SimpleKeyboardIME.kt
@@ -547,8 +547,10 @@ class SimpleKeyboardIME : InputMethodService(), OnKeyboardActionListener, Shared
                 CUSTOM_PRIMARY_COLOR, CUSTOM_ACCENT_COLOR, IS_GLOBAL_THEME_ENABLED, IS_SYSTEM_THEME_ENABLED
             )
         ) {
-            keyboardView?.setupKeyboard()
-            updateBackgroundColors()
+            if (::binding.isInitialized) {
+                keyboardView?.setupKeyboard()
+                updateBackgroundColors()
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
Added an initialization check before accessing bindings

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Keyboard/issues/335

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
