### PR TITLE
fix: prevent cached preference after reboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed an issue where sound/vibration preferences were ignored after reboot ([#372])
 
 ## [1.8.0] - 2025-12-29
 ### Added
@@ -150,6 +152,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#274]: https://github.com/FossifyOrg/Keyboard/issues/274
 [#335]: https://github.com/FossifyOrg/Keyboard/issues/335
 [#356]: https://github.com/FossifyOrg/Keyboard/issues/356
+[#372]: https://github.com/FossifyOrg/Keyboard/issues/372
 
 [Unreleased]: https://github.com/FossifyOrg/Keyboard/compare/1.8.0...HEAD
 [1.8.0]: https://github.com/FossifyOrg/Keyboard/compare/1.7.0...1.8.0

--- a/app/src/main/kotlin/org/fossify/keyboard/helpers/KeyboardFeedbackManager.kt
+++ b/app/src/main/kotlin/org/fossify/keyboard/helpers/KeyboardFeedbackManager.kt
@@ -14,7 +14,9 @@ import org.fossify.keyboard.extensions.safeStorageContext
  */
 class KeyboardFeedbackManager(private val context: Context) {
 
-    private val config = context.safeStorageContext.config
+    private val config: Config
+        get() = context.safeStorageContext.config
+
     private val audioManager by lazy {
         context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
     }


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
Updated the `KeyboardFeedbackManager` to always use the proper device storage. The preference logic should be reworked throughout the app to always save such preferences to device-protected storage.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Tested vibration and sound after rebooting the device
 
#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Keyboard/issues/372

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
