### PR TITLE
feat: hide space bar language label when only one language is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added support for custom fonts
 
+### Changed
+- Space bar language label is now hidden for single-language users
+
 ### Fixed
 - Fixed an issue where sound/vibration preferences were ignored after reboot ([#372])
 

--- a/app/src/main/kotlin/org/fossify/keyboard/services/SimpleKeyboardIME.kt
+++ b/app/src/main/kotlin/org/fossify/keyboard/services/SimpleKeyboardIME.kt
@@ -691,7 +691,7 @@ class SimpleKeyboardIME : InputMethodService(), OnKeyboardActionListener, Shared
             if (spaceKeyIndex != -1) {
                 val spaceKey = keys[spaceKeyIndex]
                 spaceKey.label = spaceKey.label.ifEmpty {
-                    getKeyboardLanguageText(config.keyboardLanguage)
+                    if (config.selectedLanguages.size > 1) getKeyboardLanguageText(config.keyboardLanguage) else ""
                 }
             }
 


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
Added visibility condition for spacebar label so it's only visible when using multiple languages. Some users find it unhelpful when there's only language enabled.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Spacebar with single language and multiple languages enabled

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
<!-- Fossify has an **issue first** policy. Please only work on **accepted** features and bug reports. -->

- Not tracked. Continuing https://github.com/FossifyOrg/Keyboard/pull/357, https://github.com/FossifyOrg/Keyboard/pull/360 

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
