### PR TITLE
refactor: remove redundant isNougatPlus check in safeStorageContext 

### DIFF
--- a/app/src/main/kotlin/org/fossify/keyboard/extensions/ContextExt.kt
+++ b/app/src/main/kotlin/org/fossify/keyboard/extensions/ContextExt.kt
@@ -39,7 +39,7 @@ import org.fossify.keyboard.interfaces.ClipsDao
 val Context.config: Config get() = Config.newInstance(applicationContext.safeStorageContext)
 
 val Context.safeStorageContext: Context
-    get() = if (isNougatPlus() && isDeviceInDirectBootMode) {
+    get() = if (isDeviceInDirectBootMode) {
         createDeviceProtectedStorageContext()
     } else {
         this


### PR DESCRIPTION
<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [ ] Feature / enhancement
- [x] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Removed redundant `isNougatPlus()` check in `safeStorageContext` getter
- The `isDeviceInDirectBootMode` property already includes an `isNougatPlus()` check internally, so the outer check is unnecessary
- This is a pure refactoring change with no behavioral difference

**Before:**
```kotlin
get() = if (isNougatPlus() && isDeviceInDirectBootMode) {
```

**After:**
```kotlin
get() = if (isDeviceInDirectBootMode) {
```

**Logical equivalence:**
- `isDeviceInDirectBootMode` returns `isNougatPlus() && !userManager.isUserUnlocked`
- Therefore, `isNougatPlus() && isDeviceInDirectBootMode` simplifies to just `isDeviceInDirectBootMode`

#### Tests performed
- Verified logical equivalence of the change
- Confirmed `isDeviceInDirectBootMode` is used standalone in `App.kt` without additional `isNougatPlus()` check, supporting this pattern

#### Before & after preview
N/A (no UI changes)

#### Closes the following issue(s)
N/A (trivial refactoring, no issue created per contribution guidelines exception)

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [ ] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.
