### PR TITLE
Fix: Lag on every key press.

### DIFF
--- a/app/src/main/kotlin/org/fossify/keyboard/services/SimpleKeyboardIME.kt
+++ b/app/src/main/kotlin/org/fossify/keyboard/services/SimpleKeyboardIME.kt
@@ -216,8 +216,10 @@ class SimpleKeyboardIME : InputMethodService(), OnKeyboardActionListener, Shared
             }
         }
 
-        keyboard?.setShifted(ShiftState.OFF)
-        keyboardView?.invalidateAllKeys()
+        if(keyboard?.mShiftState == ShiftState.ON_ONE_CHAR){
+            keyboard?.setShifted(ShiftState.OFF)
+            keyboardView?.invalidateAllKeys()
+        }
     }
 
     @RequiresApi(Build.VERSION_CODES.R)
@@ -355,7 +357,6 @@ class SimpleKeyboardIME : InputMethodService(), OnKeyboardActionListener, Shared
 
             else -> {
                 var codeChar = code.toChar()
-                val originalText = inputConnection.getExtractedText(ExtractedTextRequest(), 0)?.text
 
                 if (Character.isLetter(codeChar) && keyboard!!.mShiftState > ShiftState.OFF) {
                     if (baseContext.config.keyboardLanguage == LANGUAGE_TURKISH_Q) {
@@ -369,6 +370,7 @@ class SimpleKeyboardIME : InputMethodService(), OnKeyboardActionListener, Shared
                 // However, avoid doing that in cases when the EditText for example requires numbers as the input.
                 // We can detect that by the text not changing on pressing Space.
                 if (keyboardMode != KEYBOARD_LETTERS && inputTypeClass == TYPE_CLASS_TEXT && code == MyKeyboard.KEYCODE_SPACE) {
+                    val originalText = inputConnection.getExtractedText(ExtractedTextRequest(), 0)?.text
                     inputConnection.commitText(codeChar.toString(), 1)
                     val newText = inputConnection.getExtractedText(ExtractedTextRequest(), 0)?.text
                     if (originalText != newText) {
@@ -376,25 +378,32 @@ class SimpleKeyboardIME : InputMethodService(), OnKeyboardActionListener, Shared
                     }
                 } else {
                     when {
-                        !originalText.isNullOrEmpty() && cachedVNTelexData.isNotEmpty() -> {
-                            val fullText = originalText.toString() + codeChar.toString()
-                            val lastIndexEmpty = if (fullText.contains(" ")) {
-                                fullText.lastIndexOf(" ")
-                            } else 0
-                            if (lastIndexEmpty >= 0) {
-                                val word = fullText.subSequence(lastIndexEmpty, fullText.length).trim().toString()
-                                val wordChars = word.toCharArray()
-                                val predictWord = StringBuilder()
-                                for (char in wordChars.size - 1 downTo 0) {
-                                    predictWord.append(wordChars[char])
-                                    val shouldChangeText = predictWord.reverse().toString()
-                                    if (cachedVNTelexData.containsKey(shouldChangeText)) {
-                                        inputConnection.setComposingRegion(fullText.length - shouldChangeText.length, fullText.length)
-                                        inputConnection.setComposingText(cachedVNTelexData[shouldChangeText], fullText.length)
-                                        inputConnection.setComposingRegion(fullText.length, fullText.length)
-                                        return
+                        cachedVNTelexData.isNotEmpty() -> {
+                            val originalText = inputConnection.getExtractedText(ExtractedTextRequest(), 0)?.text
+                            if (!originalText.isNullOrEmpty()) {
+
+                                val fullText = originalText.toString() + codeChar.toString()
+                                val lastIndexEmpty = if (fullText.contains(" ")) {
+                                    fullText.lastIndexOf(" ")
+                                } else 0
+                                if (lastIndexEmpty >= 0) {
+                                    val word = fullText.subSequence(lastIndexEmpty, fullText.length).trim().toString()
+                                    val wordChars = word.toCharArray()
+                                    val predictWord = StringBuilder()
+                                    for (char in wordChars.size - 1 downTo 0) {
+                                        predictWord.append(wordChars[char])
+                                        val shouldChangeText = predictWord.reverse().toString()
+                                        if (cachedVNTelexData.containsKey(shouldChangeText)) {
+                                            inputConnection.setComposingRegion(fullText.length - shouldChangeText.length, fullText.length)
+                                            inputConnection.setComposingText(cachedVNTelexData[shouldChangeText], fullText.length)
+                                            inputConnection.setComposingRegion(fullText.length, fullText.length)
+                                            return
+                                        }
                                     }
+                                    inputConnection.commitText(codeChar.toString(), 1)
+                                    updateShiftKeyState()
                                 }
+                            } else {
                                 inputConnection.commitText(codeChar.toString(), 1)
                                 updateShiftKeyState()
                             }


### PR DESCRIPTION

<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->

originalText removed from Top. And moved to where its needed. It wont call getExtractedText every key press unless cachedVNTelexData.isNotEmpty() or we are checking for symbol->letter keyboard switch.

on updateShiftKeyState we only call invalidateAllKeys if actually ShiftState needs changing.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Tested on Samsung A51, its way better.

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
<!-- Fossify has an **issue first** policy. Please only work on **accepted** features and bug reports. -->

- Closes #429 

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
