### PR TITLE
fix: add missing letter ё to the Russian keyboard layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed the letter ё being untypeable on the Russian keyboard; long-press the е key to type it ([#405])
 
 ## [1.9.1] - 2026-02-02
 ### Changed
@@ -170,6 +172,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#335]: https://github.com/FossifyOrg/Keyboard/issues/335
 [#356]: https://github.com/FossifyOrg/Keyboard/issues/356
 [#372]: https://github.com/FossifyOrg/Keyboard/issues/372
+[#405]: https://github.com/FossifyOrg/Keyboard/issues/405
 
 [Unreleased]: https://github.com/FossifyOrg/Keyboard/compare/1.9.1...HEAD
 [1.9.1]: https://github.com/FossifyOrg/Keyboard/compare/1.9.0...1.9.1

--- a/app/src/main/res/xml/keys_letters_russian.xml
+++ b/app/src/main/res/xml/keys_letters_russian.xml
@@ -63,7 +63,7 @@
         <Key
             app:keyLabel="е"
             app:keyWidth="9.05%p"
-            app:popupCharacters="5"
+            app:popupCharacters="5ё"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="5" />
         <Key


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix

#### What changed and why
The Russian keyboard layout offered **no way to type the letter `ё`**:
- With the numbers row disabled (the default), long-pressing the `е` key only offered `5`.
- With the numbers row enabled, digits are stripped from popup characters, so long-pressing `е` showed **no popup at all** — `ё` was completely untypeable (matching the reporter's "nothing happens").

Fix: add `ё` to the `popupCharacters` of the `е` key (`"5"` → `"5ё"`), following the exact convention already used elsewhere (e.g. the Belarusian layout's `є`, `ґ`, `щ`). Long-pressing `е` now offers `ё` (and `5` when the numbers row is off; only `ё` when it is on).

I intentionally did **not** apply the reporter's suggested Belarusian (cyrillic) change: that layout already has a **dedicated `ё` key** (`app:keyLabel="ё"`), so `ё` is already directly typeable there and adding it to the `е` popup would be redundant.

#### Tests performed
Built the `fossDebug` variant and installed it on an **Android 15 (API 35) emulator**, with Fossify Keyboard set as the active IME and the Russian layout selected:
- **Before:** long-pressing `е` offered only `5`.
- **After:** long-pressing `е` shows a `5` / `Ё` popup; selecting the new entry inserts `ё` into the text field (verified the field then contained `ё`).
- Confirmed the rest of the Russian layout renders unchanged.

There are no unit tests for keyboard layout resources; this is a static XML resource change verified manually on-device.

#### Closes the following issue(s)
- Closes #405

#### Checklist
- [x] I read the contribution guidelines.
- [x] I manually tested my changes on device/emulator.
- [x] I updated the "Unreleased" section in `CHANGELOG.md`.
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

---
<sub>Coded with Opus 4.8 ultracode.</sub>
