### PR TITLE
fix: add é and ë to Ukrainian layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Fixed the letter ё being untypeable on the Russian keyboard; long-press the е key to type it ([#405])
+- Added é and ë to the Ukrainian е key's long-press popup ([#487])
 
 ## [1.9.1] - 2026-02-02
 ### Changed
@@ -173,6 +174,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#356]: https://github.com/FossifyOrg/Keyboard/issues/356
 [#372]: https://github.com/FossifyOrg/Keyboard/issues/372
 [#405]: https://github.com/FossifyOrg/Keyboard/issues/405
+[#487]: https://github.com/FossifyOrg/Keyboard/issues/487
 
 [Unreleased]: https://github.com/FossifyOrg/Keyboard/compare/1.9.1...HEAD
 [1.9.1]: https://github.com/FossifyOrg/Keyboard/compare/1.9.0...1.9.1

--- a/app/src/main/res/xml/keys_letters_ukrainian.xml
+++ b/app/src/main/res/xml/keys_letters_ukrainian.xml
@@ -55,7 +55,7 @@
             app:topSmallNumber="3" />
         <Key
             app:keyLabel="е"
-            app:popupCharacters="4"
+            app:popupCharacters="éе4ë"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="4" />
         <Key


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Added `é` and `ë` to the long-press popup for the Ukrainian Cyrillic `е` key.
- Ordered the popup as `éе4ë`, keeping ordinary `е` centred whether the number row is enabled or hidden.
- Updated the changelog.

#### Tests performed
- `xmllint --noout app/src/main/res/xml/keys_letters_ukrainian.xml`
- `./gradlew :app:processCoreDebugResources --no-daemon`

#### Related issue
- Refs #487

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [ ] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.