### PR TITLE
Delay recently-used emoji reorder until palette reopen

### DIFF
--- a/app/src/main/kotlin/org/fossify/keyboard/views/MyKeyboardView.kt
+++ b/app/src/main/kotlin/org/fossify/keyboard/views/MyKeyboardView.kt
@@ -1797,7 +1797,7 @@ class MyKeyboardView @JvmOverloads constructor(
 
     private fun setupEmojiAdapter(emojis: List<EmojiData>) {
         val emojiCategories = prepareEmojiCategories(emojis)
-        var emojiItems = prepareEmojiItems(emojiCategories)
+        val emojiItems = prepareEmojiItems(emojiCategories)
 
         val emojiLayoutManager = AutoGridLayoutManager(
             context = context,
@@ -1856,11 +1856,10 @@ class MyKeyboardView @JvmOverloads constructor(
                 mOnKeyboardActionListener!!.onText(emoji.emoji)
                 vibrateIfNeeded()
 
+                // Persist the tap now, but leave the visible order alone until the
+                // palette is reopened, so quick successive taps don't reshuffle the
+                // Recently Used row underneath the user's finger.
                 context.config.addRecentEmoji(emoji.emoji)
-                (adapter as? EmojisAdapter)?.apply {
-                    emojiItems = prepareEmojiItems(prepareEmojiCategories(emojis))
-                    updateItems(emojiItems)
-                }
             }
 
             clearOnScrollListeners()


### PR DESCRIPTION
## Summary
- Persist recent-emoji order on each tap, but do not rebuild/re-sort the on-screen Recently Used row mid-session.
- Row updates the next time the emoji palette is opened, so quick multi-taps no longer reorder under the finger.

Fixes #364

## Test plan
- [x] `./gradlew compileFossDebugKotlin`
- [x] `./gradlew detekt`
- [ ] Manually tap several emojis quickly, then close/reopen palette and confirm reorder only on reopen
